### PR TITLE
use resend for emails

### DIFF
--- a/dotsales/email_backends.py
+++ b/dotsales/email_backends.py
@@ -1,0 +1,40 @@
+import os
+import resend
+from django.core.mail.backends.base import BaseEmailBackend
+from django.core.mail.message import sanitize_address
+
+
+class ResendEmailBackend(BaseEmailBackend):
+    def __init__(self, fail_silently=False, **kwargs):
+        super().__init__(fail_silently=fail_silently, **kwargs)
+        resend.api_key = os.getenv("RESEND_API_KEY")
+
+    def send_messages(self, email_messages):
+        sent_count = 0
+        for message in email_messages:
+            try:
+                from_email = sanitize_address(message.from_email, message.encoding)
+                to_emails = [sanitize_address(addr, message.encoding) for addr in message.recipients()]
+
+                # Plain text body
+                text_body = message.body
+
+                # HTML body (if exists in alternatives)
+                html_body = None
+                for alt, mimetype in getattr(message, "alternatives", []):
+                    if mimetype == "text/html":
+                        html_body = alt
+                        break
+
+                resend.Emails.send({
+                    "from": from_email,
+                    "to": to_emails,
+                    "subject": message.subject,
+                    "text": text_body,
+                    "html": html_body or text_body,  # fallback if no HTML
+                })
+                sent_count += 1
+            except Exception as e:
+                if not self.fail_silently:
+                    raise e
+        return sent_count

--- a/dotsales/settings.py
+++ b/dotsales/settings.py
@@ -165,7 +165,11 @@ LOGIN_REDIRECT_URL = "company:landing"
 LOGOUT_REDIRECT_URL = 'users:login'
 
 # Email settings
-EMAIL_BACKEND = env('EMAIL_BACKEND')
+if env('USE_RESEND'):
+    EMAIL_BACKEND = 'dotsales.email_backends.ResendEmailBackend'
+else:
+    EMAIL_BACKEND = env('EMAIL_BACKEND')
+
 EMAIL_HOST = env('EMAIL_HOST')
 EMAIL_PORT = env('EMAIL_PORT')
 EMAIL_USE_TLS = env('EMAIL_USE_TLS')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
     "djangosetupheist>=0.6.2",
     "gunicorn>=23.0.0",
     "psycopg2-binary>=2.9.10",
+    "resend>=2.13.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,11 @@ pydantic-core==2.33.2
 pyjwt==2.10.1
     # via django-ninja-jwt
 requests==2.32.5
-    # via azure-core
+    # via
+    #   azure-core
+    #   resend
+resend==2.13.1
+    # via dotsales (pyproject.toml)
 shortuuid==1.0.13
     # via django-unicorn
 six==1.17.0
@@ -114,6 +118,7 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   pydantic
     #   pydantic-core
+    #   resend
     #   typing-inspection
 typing-inspection==0.4.1
     # via pydantic

--- a/uv.lock
+++ b/uv.lock
@@ -497,6 +497,7 @@ dependencies = [
     { name = "djangosetupheist" },
     { name = "gunicorn" },
     { name = "psycopg2-binary" },
+    { name = "resend" },
 ]
 
 [package.metadata]
@@ -514,6 +515,7 @@ requires-dist = [
     { name = "djangosetupheist", specifier = ">=0.6.2" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
+    { name = "resend", specifier = ">=2.13.1" },
 ]
 
 [[package]]
@@ -834,6 +836,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738 },
+]
+
+[[package]]
+name = "resend"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ba/de34669cd9ccf2efa65938691ae054e908cbb9c3f2f4cf5ec74d4bbc875e/resend-2.13.1.tar.gz", hash = "sha256:689e2abf17ec46acf97400c096869e95cbb0b67572b0132d1158fdbbf9b1deba", size = 15465 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6a/a5837efa1e8ff6d5c8a40574b506f85ce725126303cedec7c6e1b4382a03/resend-2.13.1-py2.py3-none-any.whl", hash = "sha256:4104d3c8f2c91113c7629e4d51ab1ca255272dd9355d2c584ab1fc10a8c65bee", size = 22279 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Enable sending emails via Resend by introducing a custom ResendEmailBackend and conditional backend selection, and add the Resend package to dependencies

New Features:
- Add ResendEmailBackend to send emails through the Resend API

Enhancements:
- Select the email backend based on the USE_RESEND environment variable

Build:
- Add resend dependency to requirements.txt and pyproject.toml